### PR TITLE
Throw/catch error in joint_trajectory_widget

### DIFF
--- a/joint_trajectory/src/joint_trajectory_model.cpp
+++ b/joint_trajectory/src/joint_trajectory_model.cpp
@@ -74,6 +74,9 @@ bool JointTrajectoryModel::hasJointTrajectorySet(const QString& key)
 
 JointTrajectoryStateItem* findJointStateItem(QStandardItem* item)
 {
+  if (!item)
+    throw std::runtime_error("findJointStateItem passed an invalid QStandardItem*");
+
   if (item->type() == static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET_STATE))
     return dynamic_cast<JointTrajectoryStateItem*>(item);
 
@@ -83,6 +86,9 @@ JointTrajectoryStateItem* findJointStateItem(QStandardItem* item)
 const tesseract_common::JointState& JointTrajectoryModel::getJointState(const QModelIndex& row) const
 {
   QStandardItem* item = itemFromIndex(row);
+
+  if (!item)
+    throw std::runtime_error("Invalid item selected, cannot get joint state");
 
   if (item->type() == static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET_TRAJECTORY))
     throw std::runtime_error("Cannot get joint state from selected joint trajectory standard item");

--- a/joint_trajectory/src/joint_trajectory_widget.cpp
+++ b/joint_trajectory/src/joint_trajectory_widget.cpp
@@ -339,15 +339,13 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
   onDisablePlayer();
   switch (data_->selected_item->type())
   {
-    case static_cast<int>(StandardItemType::COMMON_NAMESPACE):
-    {
+    case static_cast<int>(StandardItemType::COMMON_NAMESPACE): {
       data_->save_action->setDisabled(true);
       data_->remove_action->setDisabled(true);
       data_->plot_action->setDisabled(true);
       break;
     }
-    case static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET_TRAJECTORY):
-    {
+    case static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET_TRAJECTORY): {
       data_->save_action->setDisabled(true);
       data_->remove_action->setDisabled(true);
       data_->plot_action->setDisabled(false);
@@ -364,8 +362,7 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
 
       break;
     }
-    case static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET):
-    {
+    case static_cast<int>(StandardItemType::JOINT_TRAJECTORY_SET): {
       data_->save_action->setDisabled(false);
       data_->remove_action->setDisabled(false);
       data_->plot_action->setDisabled(false);
@@ -388,16 +385,22 @@ void JointTrajectoryWidget::onCurrentRowChanged(const QModelIndex& current, cons
 
       break;
     }
-    default:
-    {
+    default: {
       data_->save_action->setDisabled(true);
       data_->remove_action->setDisabled(true);
       data_->plot_action->setDisabled(true);
 
-      const tesseract_common::JointState& state = data_->model->getJointState(current_index);
-      auto details = data_->model->getJointTrajectorySetDetails(current_index);
-      emit configureJointTrajectorySet(details.first, details.second);
-      emit showJointState(state);
+      try
+      {
+        const tesseract_common::JointState& state = data_->model->getJointState(current_index);
+        auto details = data_->model->getJointTrajectorySetDetails(current_index);
+        emit configureJointTrajectorySet(details.first, details.second);
+        emit showJointState(state);
+      }
+      catch (...)
+      {
+        CONSOLE_BRIDGE_logDebug("JointTrajectoryWidget, getJointState(%i) failed, not updating", current_index);
+      }
       break;
     }
   }


### PR DESCRIPTION
Prevents crash if you click to the right of a state that isn't open